### PR TITLE
feat: allow compilation with set evm version

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -2,7 +2,6 @@
 src = 'src'
 out = 'out'
 libs = ['lib']
-
+evm_version = "shanghai"
 ffi = true
-
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/src/Deploy.sol
+++ b/src/Deploy.sol
@@ -3,6 +3,25 @@ pragma solidity ^0.8.17;
 
 import {Vm} from "forge-std/Vm.sol";
 
+enum EvmVersion {
+    Frontier,
+    Homestead,
+    Dao,
+    Tangerine,
+    SpuriousDragon,
+    Byzantium,
+    Constantinople,
+    Petersburg,
+    Istanbul,
+    MuirGlacier,
+    Berlin,
+    London,
+    ArrowGlacier,
+    GrayGlacier,
+    Paris,
+    Shanghai
+}
+
 function compile(Vm vm, string memory path) returns (bytes memory) {
     string[] memory cmd = new string[](3);
     cmd[0] = "huffc";
@@ -11,13 +30,31 @@ function compile(Vm vm, string memory path) returns (bytes memory) {
     return vm.ffi(cmd);
 }
 
-function compileWithVersion(Vm vm, string memory path, string memory evmVersion) returns (bytes memory) {
+function compileWithVersion(Vm vm, string memory path, EvmVersion evmVersion ) returns (bytes memory) {
+    string[16] memory evmVersions = [
+        "frontier", 
+        "homestead", 
+        "dao", 
+        "tangerine_whistle", 
+        "spurious_dragon", 
+        "byzantium", 
+        "constantinople", 
+        "petersburg", 
+        "istanbul",
+        "muir_glacier",
+        "berlin",
+        "london",
+        "arrow_glacier",
+        "gray_glacier",
+        "paris",
+        "shanghai"
+    ];
     string[] memory cmd = new string[](5);
     cmd[0] = "huffc";
     cmd[1] = "--bytecode";
     cmd[2] = path;
     cmd[3] = "--evm-version";
-    cmd[4] = evmVersion;
+    cmd[4] = evmVersions[uint8(evmVersion)];
     return vm.ffi(cmd);
 }
 

--- a/src/Deploy.sol
+++ b/src/Deploy.sol
@@ -30,16 +30,16 @@ function compile(Vm vm, string memory path) returns (bytes memory) {
     return vm.ffi(cmd);
 }
 
-function compileWithVersion(Vm vm, string memory path, EvmVersion evmVersion ) returns (bytes memory) {
+function compileWithVersion(Vm vm, string memory path, EvmVersion evmVersion) returns (bytes memory) {
     string[16] memory evmVersions = [
-        "frontier", 
-        "homestead", 
-        "dao", 
-        "tangerine_whistle", 
-        "spurious_dragon", 
-        "byzantium", 
-        "constantinople", 
-        "petersburg", 
+        "frontier",
+        "homestead",
+        "dao",
+        "tangerine_whistle",
+        "spurious_dragon",
+        "byzantium",
+        "constantinople",
+        "petersburg",
         "istanbul",
         "muir_glacier",
         "berlin",
@@ -68,11 +68,7 @@ function create(bytes memory bytecode, uint256 value) returns (address deployedA
     if (deployedAddress == address(0)) revert DeploymentFailure(bytecode);
 }
 
-function create2(
-    bytes memory bytecode,
-    uint256 value,
-    bytes32 salt
-) returns (address deployedAddress) {
+function create2(bytes memory bytecode, uint256 value, bytes32 salt) returns (address deployedAddress) {
     assembly {
         deployedAddress := create2(value, add(bytecode, 0x20), mload(bytecode), salt)
     }

--- a/src/Deploy.sol
+++ b/src/Deploy.sol
@@ -11,6 +11,16 @@ function compile(Vm vm, string memory path) returns (bytes memory) {
     return vm.ffi(cmd);
 }
 
+function compileWithVersion(Vm vm, string memory path, string memory evmVersion) returns (bytes memory) {
+    string[] memory cmd = new string[](5);
+    cmd[0] = "huffc";
+    cmd[1] = "--bytecode";
+    cmd[2] = path;
+    cmd[3] = "--evm-version";
+    cmd[4] = evmVersion;
+    return vm.ffi(cmd);
+}
+
 error DeploymentFailure(bytes bytecode);
 
 function create(bytes memory bytecode, uint256 value) returns (address deployedAddress) {

--- a/test/Deploy.t.sol
+++ b/test/Deploy.t.sol
@@ -4,8 +4,8 @@ pragma solidity ^0.8.13;
 import "forge-std/Test.sol";
 import {EvmVersion, compile, compileWithVersion, create, create2, appendArgs} from "src/Deploy.sol";
 
-using { compile, compileWithVersion } for Vm;
-using { appendArgs, create, create2 } for bytes;
+using {compile, compileWithVersion} for Vm;
+using {appendArgs, create, create2} for bytes;
 
 address constant mockDeployment = address(0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f);
 
@@ -13,23 +13,16 @@ bytes32 constant salt = 0x713e2693e50c074b604477dac814a71316b96441e6c214c3755e73
 address constant mockDeployment2 = address(0x5231BC5F3f030e12764c0441B391516Cfe5C3459);
 
 contract DeployTest is Test {
-
     function testCompile() public {
         bytes memory mockBytecode = hex"60088060093d393df360015f5260205ff3";
 
-        assertEq(
-            mockBytecode,
-            vm.compile("test/mocks/Mock.huff")
-        );
+        assertEq(mockBytecode, vm.compile("test/mocks/Mock.huff"));
     }
 
     function testCompileWithVersion() public {
         bytes memory mockBytecode = hex"600a8060093d393df3600160005260206000f3";
 
-        assertEq(
-            mockBytecode,
-            vm.compileWithVersion("test/mocks/Mock.huff", EvmVersion.Paris)
-        );
+        assertEq(mockBytecode, vm.compileWithVersion("test/mocks/Mock.huff", EvmVersion.Paris));
     }
 
     function testCreate() public {
@@ -45,7 +38,7 @@ contract DeployTest is Test {
     }
 
     function testCreate2() public {
-        address deployment = vm.compile("test/mocks/Mock.huff").create2({ value: 0, salt: salt });
+        address deployment = vm.compile("test/mocks/Mock.huff").create2({value: 0, salt: salt});
 
         assertEq(deployment, mockDeployment2);
     }
@@ -54,10 +47,8 @@ contract DeployTest is Test {
         bytes32[] memory args = new bytes32[](1);
         args[0] = salt;
 
-        (bool success, bytes memory data) = vm.compile("test/mocks/MockWithArg.huff")
-            .appendArgs(args)
-            .create({value: 0})
-            .call(new bytes(0));
+        (bool success, bytes memory data) =
+            vm.compile("test/mocks/MockWithArg.huff").appendArgs(args).create({value: 0}).call(new bytes(0));
 
         require(success, "failed call");
 

--- a/test/Deploy.t.sol
+++ b/test/Deploy.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.13;
 
 import "forge-std/Test.sol";
-import {compile, compileWithVersion, create, create2, appendArgs} from "src/Deploy.sol";
+import {EvmVersion, compile, compileWithVersion, create, create2, appendArgs} from "src/Deploy.sol";
 
 using { compile, compileWithVersion } for Vm;
 using { appendArgs, create, create2 } for bytes;
@@ -28,7 +28,7 @@ contract DeployTest is Test {
 
         assertEq(
             mockBytecode,
-            vm.compileWithVersion("test/mocks/Mock.huff", "paris")
+            vm.compileWithVersion("test/mocks/Mock.huff", EvmVersion.Paris)
         );
     }
 

--- a/test/Deploy.t.sol
+++ b/test/Deploy.t.sol
@@ -2,24 +2,33 @@
 pragma solidity ^0.8.13;
 
 import "forge-std/Test.sol";
-import {compile, create, create2, appendArgs} from "src/Deploy.sol";
+import {compile, compileWithVersion, create, create2, appendArgs} from "src/Deploy.sol";
 
-using { compile } for Vm;
+using { compile, compileWithVersion } for Vm;
 using { appendArgs, create, create2 } for bytes;
 
-address constant mockDeployment = address(0xCe71065D4017F316EC606Fe4422e11eB2c47c246);
+address constant mockDeployment = address(0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f);
 
 bytes32 constant salt = 0x713e2693e50c074b604477dac814a71316b96441e6c214c3755e73aa144608d8;
-address constant mockDeployment2 = address(0xA23399c32fb4D4B9FEBB93302509808A599ed0fc);
+address constant mockDeployment2 = address(0x5231BC5F3f030e12764c0441B391516Cfe5C3459);
 
 contract DeployTest is Test {
 
     function testCompile() public {
-        bytes memory mockBytecode = hex"600a8060093d393df3600160005260206000f3";
+        bytes memory mockBytecode = hex"60088060093d393df360015f5260205ff3";
 
         assertEq(
             mockBytecode,
             vm.compile("test/mocks/Mock.huff")
+        );
+    }
+
+    function testCompileWithVersion() public {
+        bytes memory mockBytecode = hex"600a8060093d393df3600160005260206000f3";
+
+        assertEq(
+            mockBytecode,
+            vm.compileWithVersion("test/mocks/Mock.huff", "paris")
         );
     }
 


### PR DESCRIPTION
This PR introduces a new function `compileWithVersion` that allows the developer to set the `evm_version` they want to compile their Huff code to. `compile` as is will default to `shanghai` and force usage of `PUSH0` while this allows for flexibility with the version of EVM to compile to. 

`forge-std` and the respective tests have been updated accordingly as well.