### PR TITLE
Fixed example in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,14 @@ The following functions are exposed by importing.
 import "forge-std/Script.sol";
 import {compile, create} from "huff-runner/Deploy.sol";
 
-using { compile } for Vm;
 using { create } for bytes;
 
 contract HuffDeployScript is Script {
-    function run() {
-        vm.broadcast();
 
-        address deployment = vm.compile("huff/MyContract.huff").create({value: 0});
-
-        vm.stopBroadcast()
+    function run() public {
+        vm.startBroadcast();
+        address deployment = compile(vm, "huff/MyContract.huff").create({value: 0});
+        vm.stopBroadcast();
     }
 }
 ```


### PR DESCRIPTION
**Issue**: The usage example provided in the readme does not work due to typos, etc...

In this PR I provide an example that works as intended (based on minor modifications of the previously provided example).